### PR TITLE
Support all 2.x mautic versions

### DIFF
--- a/whitelabeler.php
+++ b/whitelabeler.php
@@ -703,7 +703,6 @@ class Whitelabeler
                 'message' => 'Compatible version found (' . $latest2xVersion . ')'
             );
         } else {
-
             return array(
                 'status' => 0,
                 'message' => 'The version of Mautic you are using (' . $version . ') is not currently supported.'

--- a/whitelabeler.php
+++ b/whitelabeler.php
@@ -681,6 +681,8 @@ class Whitelabeler
     {
         $path = 'templates';
         $versions = array();
+        $regexFor2xMauticVersion = '/^2\.\d+\.\d+(-.+)*/i';
+
         foreach (new DirectoryIterator($path) as $file) {
             if ($file->isDot()) continue;
             if ($file->isDir()) {
@@ -688,11 +690,17 @@ class Whitelabeler
             }
         }
         if (in_array(substr($version, 0, 3), $versions) || in_array($version, $versions)) {
-
             return array(
                 'status' => 1,
                 'version' => $version,
                 'message' => 'Compatible version found (' . $version . ')'
+            );
+        } else if (preg_match($regexFor2xMauticVersion, $version)) { // we assume that once the major version doesn't change, we can run the whitelabeler with the latest 2.x template
+            $latest2xVersion = end(preg_grep($regexFor2xMauticVersion, $versions));
+            return array(
+                'status' => 1,
+                'version' => $latest2xVersion,
+                'message' => 'Compatible version found (' . $latest2xVersion . ')'
             );
         } else {
 


### PR DESCRIPTION
Changelog:
- feat: use latest version of 2.x templates for 2.x mautic versions

Tested with version `2.15.3`:
<img width="1662" alt="Screen Shot 2019-11-21 at 1 22 08 PM" src="https://user-images.githubusercontent.com/5022877/69361001-f29da480-0c61-11ea-9afe-b0133332c7fe.png">

<img width="402" alt="Screen Shot 2019-11-21 at 1 26 55 PM" src="https://user-images.githubusercontent.com/5022877/69361315-9f782180-0c62-11ea-83a6-3ce63847bfc5.png">
